### PR TITLE
重構感知系統並新增進食行為邏輯

### DIFF
--- a/Assets/Script/Perception.cs
+++ b/Assets/Script/Perception.cs
@@ -5,40 +5,154 @@ using static UnityEngine.GraphicsBuffer;
 
 public static class Perception
 {
-    public static Creature HasTarget(Creature current_creature, int target_ID)
+    public static class Creatures
     {
-        foreach (var each_species in Manager.species)
+        public static Creature HasTarget(Creature current_creature, int target_ID)
         {
-            if(target_ID!=each_species.attributes.species_ID) continue;
-            foreach(var each_creature in each_species.creatures){
-                float distance = Vector2.Distance(current_creature.transform.position, each_creature.transform.position);
-                if (distance > current_creature.PerceptionRange) continue;
-                return each_creature;
-            }
-        }
-        return null;
-    }
-    public static int CountTargetNumber(Creature current_creature, int target_ID)
-    {
-        int count = 0;
-        foreach (var each_species in Manager.species)
-        {
-            if (target_ID != each_species.attributes.species_ID) continue;
-            foreach (var each_creature in each_species.creatures)
+            foreach (var each_species in Manager.species)
             {
-                float distance = Vector2.Distance(current_creature.transform.position, each_creature.transform.position);
-                if (distance > current_creature.PerceptionRange) continue;
+                if (target_ID != each_species.attributes.species_ID) continue;
+                foreach (var each_creature in each_species.creatures)
+                {
+                    float distance = Vector2.Distance(current_creature.transform.position, each_creature.transform.position);
+                    if (distance > current_creature.PerceptionRange) continue;
+                    return each_creature;
+                }
+            }
+            return null;
+        }
+        public static bool HasTarget(Creature creature, List<int> target_ID_list)
+        {
+            foreach (var target in target_ID_list)
+            {
+                if (HasTarget(creature, target)) return true;
+            }
+            return false;
+        }
+
+        public static int CountTargetNumber(Creature current_creature, int target_ID)
+        {
+            int count = 0;
+            foreach (var each_species in Manager.species)
+            {
+                if (target_ID != each_species.attributes.species_ID) continue;
+                foreach (var each_creature in each_species.creatures)
+                {
+                    float distance = Vector2.Distance(current_creature.transform.position, each_creature.transform.position);
+                    if (distance > current_creature.PerceptionRange) continue;
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public static int CountTarget(Creature current_creature, List<int> target_ID_list)
+        {
+            int count = 0;
+            foreach (var target_ID in target_ID_list)
+            {
+                count += CountTargetNumber(current_creature, target_ID);
+            }
+            return count;
+        }
+
+        public static List<Creature> GetAllTargets(Creature current_creature, int target_ID)
+        {
+            List<Creature> targetsUUID = new();
+            foreach (var each_species in Manager.species)
+            {
+                if (target_ID != each_species.attributes.species_ID) continue;
+                foreach (var each_creature in each_species.creatures)
+                {
+                    float distance = Vector2.Distance(current_creature.transform.position, each_creature.transform.position);
+                    if (distance > current_creature.PerceptionRange) continue;
+                    targetsUUID.Add(each_creature);
+                }
+            }
+            targetsUUID.Sort();
+            return targetsUUID;
+        }
+
+        public static List<Creature> GetAllTargets(Creature current_creature, List<int> target_ID_list)
+        {
+            List<Creature> targets = new();
+            foreach (var target_ID in target_ID_list)
+            {
+                targets.AddRange(GetAllTargets(current_creature, target_ID));
+            }
+            targets.Sort();
+            return targets;
+        }
+    }
+
+    public class Items
+    {
+        public static bool HasTarget(Creature creature, FoodType food_type)
+        {
+            foreach (var each_dropped_item in Manager.FoodItems)
+            {
+                float distance = Vector2.Distance(creature.transform.position, each_dropped_item.transform.position);
+                if (distance > creature.PerceptionRange) continue;
+                if (each_dropped_item.Type != food_type) continue;
+                return true;
+            }
+            return false;
+        }
+
+        public static bool HasTarget(Creature creature, List<FoodType> food_type_list)
+        {
+            foreach (var food_type in food_type_list)
+            {
+                if (HasTarget(creature, food_type)) return true;
+            }
+            return false;
+        }
+
+        public static int CountTargetNumber(Creature creature, FoodType food_type)
+        {
+            int count = 0;
+            foreach (var each_dropped_item in Manager.FoodItems)
+            {
+                float distance = Vector2.Distance(creature.transform.position, each_dropped_item.transform.position);
+                if (distance > creature.PerceptionRange) continue;
+                if (each_dropped_item.Type != food_type) continue;
                 count++;
             }
+            return count;
         }
-        return count;
-    } 
-    public static bool HasTarget(Creature creature, List<int> target_ID_list)
-    {
-        foreach (var target in target_ID_list)
+
+        public static int CountTarget(Creature creature, List<FoodType> food_type_list)
         {
-            if (HasTarget(creature, target)) return true;
+            int count = 0;
+            foreach (var food_type in food_type_list)
+            {
+                count += CountTargetNumber(creature, food_type);
+            }
+            return count;
         }
-        return false;
+
+        public static List<Edible> GetAllTargets(Creature creature, FoodType food_type)
+        {
+            List<Edible> targets = new();
+            foreach (var each_dropped_item in Manager.FoodItems)
+            {
+                float distance = Vector2.Distance(creature.transform.position, each_dropped_item.transform.position);
+                if (distance > creature.PerceptionRange) continue;
+                if (each_dropped_item.Type != food_type) continue;
+                targets.Add(each_dropped_item);
+            }
+            return targets;
+        }
+
+        public static List<Edible> GetAllTargets(Creature creature, List<FoodType> food_type_list)
+        {
+            List<Edible> targets = new();
+            foreach (var food_type in food_type_list)
+            {
+                targets.AddRange(GetAllTargets(creature, food_type));
+            }
+            targets.Sort();
+            return targets;
+        }
     }
 }

--- a/Assets/Script/action/EatAction.cs
+++ b/Assets/Script/action/EatAction.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+class EatAction : ActionBase
+{
+    public override ActionType Type => ActionType.Eat;
+    public override int Cooldown => 3;
+    public override bool IsConditionMet(Creature creature)
+    {
+        // TODO: 檢查是否有可食用的目標
+        return Perception.Items.HasTarget(creature, creature.FoodTypes);
+    }
+    public override float GetWeight(Creature creature)
+    {
+        // 根據飢餓值決定進食權重，飢餓值越高，進食權重越高
+        return 1 - creature.Hunger / creature.MaxHunger;
+    }
+    public override bool IsSuccess(Creature creature)
+    {
+        // 80% 機率成功進食
+        return Random.Range(0, 10) < 8;
+    }
+    public override void Execute(Creature creature)
+    {
+        List<Edible> edibleTargets = Perception.Items.GetAllTargets(creature, creature.FoodTypes);
+        if (edibleTargets.Count > 0)
+        {
+            Edible food = edibleTargets[0];
+            //TODO: 走過去
+            this.TempMove(Vector2Int.RoundToInt(food.transform.position));
+            //TODO: Corutine 等待走過去
+            food.Eaten();
+            creature.Hunger = Mathf.Min(creature.Hunger + food.NutritionalValue, creature.MaxHunger);
+        }
+    }
+
+    private void TempMove(Vector2Int goal) { }
+}

--- a/Assets/Script/action/MoveAction.cs
+++ b/Assets/Script/action/MoveAction.cs
@@ -16,7 +16,7 @@ public class MoveAction : ActionBase
 	public override float GetWeight(Creature creature)
 	{
 		// 根據飢餓值決定移動權重，飢餓值越高，移動權重越高
-		return (creature.Hunger / creature.MaxHunger) / Perception.CountTargetNumber(creature, creature.SpeciesID);
+		return (creature.Hunger / creature.MaxHunger) / Perception.Creatures.CountTargetNumber(creature, creature.SpeciesID);
 	}
 
 	public override bool IsSuccess(Creature creature)

--- a/Assets/Script/base/Creature.cs
+++ b/Assets/Script/base/Creature.cs
@@ -9,7 +9,6 @@ public abstract class Creature : MonoBehaviour, Tickable
 {
     // 玩家決定
     [Header("=== 玩家決定 ===")]
-    public GameObject CreatureObject {  get; private set; }
     [SerializeField] private int species_ID;
     public int SpeciesID { get => species_ID; set => species_ID = value; }
     [SerializeField] private float size;
@@ -55,8 +54,8 @@ public abstract class Creature : MonoBehaviour, Tickable
     [SerializeField] private float healthRegeneration;
     public float HealthRegeneration { get => healthRegeneration; set => healthRegeneration = value; }
 
-    [SerializeField] private DietType diet;
-    public DietType Diet { get => diet; set => diet = value; }
+    [SerializeField] private List<FoodType> foodTypes;
+    public List<FoodType> FoodTypes { get => foodTypes; set => foodTypes = value; }
 
     [SerializeField] private BodyType body;
     public BodyType Body { get => body; set => body = value; }
@@ -83,7 +82,6 @@ public abstract class Creature : MonoBehaviour, Tickable
 
     public void Initialize(CreatureAttributes creatureAttributes , GameObject creature_object)
     {
-        CreatureObject = creature_object;
         //個體編號
         _UUID = System.Guid.NewGuid().ToString();
         float variationFactor() => UnityEngine.Random.Range(-creatureAttributes.variation, creatureAttributes.variation);
@@ -109,7 +107,7 @@ public abstract class Creature : MonoBehaviour, Tickable
         //計算衍生屬性
         SleepTime = SleepingCycle[1] - SleepingCycle[0];
         HungerRate = AttributesCalculator.CalculateHungerRate(Size, Speed, AttackPower);
-        MaxHunger = AttributesCalculator.CalculateMaxHunger(Size, BaseHealth, Diet);
+        MaxHunger = AttributesCalculator.CalculateMaxHunger(Size, BaseHealth, FoodTypes);
         ReproductionInterval = AttributesCalculator.CalculateReproductionInterval(Size, BaseHealth);
         HealthRegeneration = AttributesCalculator.CalculateHealthRegeneration(BaseHealth, Size, SleepTime);
         //初始狀態
@@ -166,7 +164,7 @@ public abstract class Creature : MonoBehaviour, Tickable
         attributes.lifespan = Lifespan;
         attributes.perception_range = PerceptionRange;
         attributes.sleeping_cycle = SleepingCycle;
-        attributes.Diet = Diet;
+        attributes.FoodTypes = FoodTypes;
         attributes.Body = Body;
         attributes.prey_ID_list = PreyIDList;
         attributes.predator_ID_list = PredatorIDList;

--- a/Assets/Script/base/Edible.cs
+++ b/Assets/Script/base/Edible.cs
@@ -3,20 +3,22 @@ using UnityEngine;
 // Abstract base class for all edible objects
 public abstract class Edible : MonoBehaviour, Tickable
 {
+    // Unique identifier for the edible object
+    public string UUID { get; protected set; }
     // The remaining lifespan of the object (tick)
-    public int lifeSpan { get; protected set; }
+    public abstract int LifeSpan { get; protected set; }
 
     // The amount of hunger this object restores when eaten.
-    public float nutritionalValue { get; protected set; }
+    public abstract float NutritionalValue { get; }
 
     // The category of this food (e.g., Plant or Meat).
-    public FoodType Type { get; protected set; }
+    public abstract FoodType Type { get; }
 
     // This method is called once per tick by the Manager.
     public virtual void OnTick()
     {
-        lifeSpan--;
-        if (lifeSpan <= 0)
+        LifeSpan--;
+        if (LifeSpan <= 0)
         {
             Destroy(this.gameObject);
         }
@@ -27,5 +29,9 @@ public abstract class Edible : MonoBehaviour, Tickable
         Destroy(this.gameObject);
     }
 
-    public abstract void Initialize(Vector2 position);
+    public void Initialize(Vector2Int position)
+    {
+        this.UUID = System.Guid.NewGuid().ToString();
+        this.transform.position = (Vector3Int)position;
+    }
 }

--- a/Assets/Script/base/Manager.cs
+++ b/Assets/Script/base/Manager.cs
@@ -7,14 +7,13 @@ using System.Linq;
 public class Manager : MonoBehaviour
 {
     public static List<Species> species;
-    private List<GameObject> meat;
-    private List<GameObject> grass;
+    public static List<Edible> FoodItems;
     private List<Tickable> tickables;
-    public float tickInterval = 1f; // 每個遊戲單位時間 = 1 秒
+    public float tickInterval = 1f / 30; // 每個遊戲單位時間 (秒)
     private float tickTimer = 0;
     private int mixTickTime = 240000;
     private int tickTime = 0;
-    public Dictionary<int, Species> species_dictionary = new Dictionary<int, Species>();
+
     void Start()
     {
         

--- a/Assets/Script/data/Constant.cs
+++ b/Assets/Script/data/Constant.cs
@@ -12,13 +12,6 @@ public enum BodyType
     Large
 }
 
-public enum DietType
-{
-    Herbivore,  //草食
-    Carnivore,  //肉食
-    Omnivore    //雜食
-}
-
 public enum ActionType
 {
     Move,
@@ -32,7 +25,8 @@ public enum ActionType
 public enum FoodType
 {
     Plant,
-    Meat
+    Meat,
+    Carrion
 }
 public struct CreatureAttributes
 {
@@ -46,7 +40,7 @@ public struct CreatureAttributes
     public float variation;
     public float perception_range;
     public int[] sleeping_cycle;
-    public DietType Diet { get; set; }
+    public List<FoodType> FoodTypes;
     public BodyType Body { get; set; }     //最終體型
     public List<int> prey_ID_list;       //新增食物列表
     public List<int> predator_ID_list;   //新增天敵列表
@@ -63,9 +57,12 @@ public static class AttributesCalculator{
     {
         return size * speed + attack_power;
     }
-    public static float CalculateMaxHunger(float size, float base_health, DietType diet)
+    public static float CalculateMaxHunger(float size, float base_health, List<FoodType> foods)
     {
-        float dietFactor = new float[] { 0.8f, 1.2f, 1.0f }[(int)diet];
+        float dietFactor = 1.0f;
+        if (foods.Contains(FoodType.Plant) && (foods.Contains(FoodType.Meat) || foods.Contains(FoodType.Carrion))) dietFactor = 1.0f;
+        else if (foods.Contains(FoodType.Meat) || foods.Contains(FoodType.Carrion)) dietFactor = 1.2f;
+        else if (foods.Contains(FoodType.Plant)) dietFactor = 0.8f;
         return size * base_health * dietFactor;
     }
     public static float CalculateReproductionInterval(float size, float base_health)

--- a/Assets/Script/food/Carrion.cs
+++ b/Assets/Script/food/Carrion.cs
@@ -2,11 +2,7 @@ using UnityEngine;
 
 public class Carrion : Edible
 {
-	public override void Initialize(Vector2 position)
-	{
-		this.lifeSpan = 300;
-		this.nutritionalValue = 5f;
-		this.transform.position = position;
-		this.Type = FoodType.Meat;
-	}
+    public override int LifeSpan { get; protected set; } = 100;
+    public override float NutritionalValue => 20f;
+	public override FoodType Type => FoodType.Carrion;
 }

--- a/Assets/Script/food/Grass.cs
+++ b/Assets/Script/food/Grass.cs
@@ -2,11 +2,7 @@ using UnityEngine;
 
 public class Grass : Edible
 {
-    public override void Initialize(Vector2 position)
-    {
-        this.lifeSpan = 500;
-        this.nutritionalValue = 10f;
-        this.transform.position = position;
-        this.Type = FoodType.Plant;
-    }
+    public override int LifeSpan { get; protected set; } = 500;
+    public override float NutritionalValue => 10f;
+    public override FoodType Type => FoodType.Plant;
 }

--- a/Assets/Script/food/Meat.cs
+++ b/Assets/Script/food/Meat.cs
@@ -2,13 +2,7 @@ using UnityEngine;
 
 public class Meat : Edible
 {
-    public override void Initialize(Vector2 position)
-    {
-        this.lifeSpan = 150;
-        this.nutritionalValue = 30f;
-        this.transform.position = position;
-        this.Type = FoodType.Meat;
-    }
-
-    // Future enhancement: Could add logic here to turn into Carrion when lifespan is empty or low.
+    public override int LifeSpan { get; protected set; } = 150;
+    public override float NutritionalValue => 30f;
+    public override FoodType Type => FoodType.Meat;
 }


### PR DESCRIPTION
重構 Perception 類別為 Creatures 和 Items，分別處理生物與物品的感知邏輯，並新增多目標與多食物類型的支援。 新增 EatAction 類別，實現進食行為的條件檢查、權重計算與執行邏輯。
移除 DietType，改用 FoodType 列表表示食物偏好，並更新相關屬性與計算邏輯。
統一 Edible 類別的屬性與初始化邏輯，並新增 UUID 作為唯一標識。
合併 Manager 中的食物列表為 FoodItems，並提升 tick 更新頻率至每秒 30 次。 新增 FoodType 類型 Carrion，並更新相關類別的屬性與邏輯。