### PR TITLE
重構 Tickable 機制並改用事件驅動架構

### DIFF
--- a/Assets/Script/base/Creature.cs
+++ b/Assets/Script/base/Creature.cs
@@ -5,7 +5,7 @@ using System;
 using UnityEngine;
 
 
-public class Creature : MonoBehaviour, Tickable
+public class Creature : MonoBehaviour, ITickable
 {
     // 玩家決定
     [Header("=== 玩家決定 ===")]
@@ -175,6 +175,10 @@ public class Creature : MonoBehaviour, Tickable
         attributes.action_list = ActionList;
         return attributes;
     }
+    public void OnEnable()
+    {
+        Manager.OnTick += OnTick;
+    }
     public void OnTick()
     {
         //回血、餓死、老死、繁殖冷卻
@@ -212,6 +216,10 @@ public class Creature : MonoBehaviour, Tickable
         {
             DoAction();
         }
+    }
+    public void OnDisable()
+    {
+        Manager.OnTick -= OnTick;
     }
     // 巢狀類別：專門負責移動邏輯
     private class Movement

--- a/Assets/Script/base/Edible.cs
+++ b/Assets/Script/base/Edible.cs
@@ -1,7 +1,8 @@
+using System.Xml.Serialization;
 using UnityEngine;
 
 // Abstract base class for all edible objects
-public abstract class Edible : MonoBehaviour, Tickable
+public abstract class Edible : MonoBehaviour, ITickable
 {
     // Unique identifier for the edible object
     public string UUID { get; protected set; }
@@ -14,6 +15,11 @@ public abstract class Edible : MonoBehaviour, Tickable
     // The category of this food (e.g., Plant or Meat).
     public abstract FoodType Type { get; }
 
+    public void OnEnable()
+    {
+        Manager.OnTick += OnTick;
+    }
+
     // This method is called once per tick by the Manager.
     public virtual void OnTick()
     {
@@ -24,7 +30,10 @@ public abstract class Edible : MonoBehaviour, Tickable
         }
     }
 
-    
+    public void OnDisable()
+    {
+        Manager.OnTick -= OnTick;
+    }
 
     public virtual void Eaten()
     {

--- a/Assets/Script/base/Manager.cs
+++ b/Assets/Script/base/Manager.cs
@@ -3,10 +3,9 @@ using UnityEngine;
 
 public class Manager : MonoBehaviour
 {
-
+    public static event System.Action OnTick;
     public static List<Species> species;
     public static List<Edible> FoodItems;
-    private readonly List<Tickable> tickables;
     public float tickInterval = 1f / 30; // 每個遊戲單位時間 (秒)
     private float tickTimer = 0;
     private int mixTickTime = 240000;
@@ -26,10 +25,7 @@ public class Manager : MonoBehaviour
             tickTimer -= tickInterval;
             tickTime = (tickTime + 1) % mixTickTime;
             // 在這裡處理每個遊戲時間單位的邏輯
-            foreach (var tickable in tickables)
-            {
-                tickable.OnTick();
-            }
+            OnTick?.Invoke();
         }
     }
     private void Initialize()

--- a/Assets/Script/base/Tickable.cs
+++ b/Assets/Script/base/Tickable.cs
@@ -1,6 +1,12 @@
 using UnityEngine;
-public interface Tickable
+public interface ITickable
 {
+    // This method is called once per tick by the Manager.
     void OnTick();
-    //void JoinManager(Manager manager);
+    // This method is called when the object is enabled.
+    // Must subscribe to the Manager's OnTick event here.
+    void OnEnable();
+    // This method is called when the object is disabled.
+    // Must unsubscribe from the Manager's OnTick event here.
+    void OnDisable();
 }


### PR DESCRIPTION
重命名 Tickable 為 ITickable，並新增 OnEnable 和 OnDisable 方法，要求類別在啟用和停用時訂閱或取消訂閱 Manager 的 OnTick 事件。 在 Creature 和 Edible 類別中實作 ITickable，並新增相關邏輯。
移除 Manager 中的 tickables 列表，改用靜態事件 OnTick 通知訂閱者執行每個 tick 的邏輯。