### PR TITLE
限制食物生成於草地地形

### DIFF
--- a/Assets/Script/base/Manager.cs
+++ b/Assets/Script/base/Manager.cs
@@ -133,6 +133,7 @@ public class Manager : MonoBehaviour
         foreach (var pos in random_positions)
         {
             if (fooditems.ContainsKey(pos)) continue;
+            if (TerrainGenerator.Instance.GetDefinitionMap().GetTerrain(pos) != TerrainType.Grass) continue;
             // Spawn food item
             GameObject food_item_prefab = Resources.Load<GameObject>("Prefabs/Edible/Grass");
             GameObject food_item_object = Instantiate(food_item_prefab);


### PR DESCRIPTION
新增邏輯以檢查隨機位置的地形類型，確保食物只會生成在 `TerrainType.Grass` 的地形上，避免在其他地形生成不合理的食物。