### PR TITLE
新增 CreaturePool 與 TickManeger 物件池與 Tick 管理器

### DIFF
--- a/Assets/Resources/Tileset_datas/NewSimpleTileData.asset
+++ b/Assets/Resources/Tileset_datas/NewSimpleTileData.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7aceae5f2e5dac44e98a0de0d9087b13, type: 3}
+  m_Name: NewSimpleTileData
+  m_EditorClassIdentifier: Assembly-CSharp::SimpleTileData
+  terrainType: 0
+  tile: {fileID: 0}

--- a/Assets/Resources/Tileset_datas/NewSimpleTileData.asset.meta
+++ b/Assets/Resources/Tileset_datas/NewSimpleTileData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4592a6a5016e5bd4f86825d3bfc3a087
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/base/CreaturePool.cs
+++ b/Assets/Script/base/CreaturePool.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEngine.Pool;
+
+public static class CreaturePool
+{
+    // Object pool for Creature instances
+    private static ObjectPool<Creature> pool = new(
+        createFunc: CreateCreature,
+        actionOnGet: ActionOnGet,
+        actionOnRelease: ActionOnRelease,
+        actionOnDestroy: ActionOnDestroy,
+        collectionCheck: false,
+        defaultCapacity: 200,
+        maxSize: 10000
+    );
+
+    public static Creature GetCreature()
+    {
+        return pool.Get();
+    }
+
+    public static void ReleaseCreature(Creature creature)
+    {
+        pool.Release(creature);
+    }
+
+    // Factory method to create a new Creature instance
+    private static Creature CreateCreature()
+    {
+        GameObject prefab = Resources.Load<GameObject>("Prefabs/Creature");
+        return GameObject.Instantiate(prefab).GetComponent<Creature>();
+    }
+
+    private static void ActionOnGet(Creature creature)
+    {         
+        // 初始化或重置 Creature 狀態
+    }
+
+    private static void ActionOnRelease(Creature creature)
+    {
+        // 清理 Creature 狀態
+    }
+
+    private static void ActionOnDestroy(Creature creature)
+    {
+        // 銷毀 Creature 資源
+        Object.Destroy(creature.gameObject);
+    }
+}

--- a/Assets/Script/base/CreaturePool.cs.meta
+++ b/Assets/Script/base/CreaturePool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8ba9276fa754f14580ac94fa1a47e3a

--- a/Assets/Script/game_control/TIckManeger.cs
+++ b/Assets/Script/game_control/TIckManeger.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using System.Collections.Generic;
+using System;
+
+public class TickManeger: MonoBehaviour
+{
+    public static TickManeger Instance { get; private set; }
+
+    public TickManeger()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Debug.LogError("TickManeger instance already exists!");
+            return;
+        }
+        Instance = this;
+    }
+
+    private readonly List<Action> tickable = new(); 
+    private int tickCount = 0;
+    private const int TicksPerSecond = 30;
+    private float realtime_counter = 0;
+
+    public void RegisterTickable(Action onTick)
+    {
+        if (!this.tickable.Contains(onTick))
+        {
+            this.tickable.Add(onTick);
+        }
+    }
+
+    public void UnregisterTickable(Action onTick)
+    {
+        if (this.tickable.Contains(onTick))
+        {
+            this.tickable.Remove(onTick);
+        }
+    }
+
+    private void Tick()
+    {
+        tickCount++;
+        foreach (var t in tickable)
+        {
+            t?.Invoke();
+        }
+    }
+
+    private void Update()
+    {
+        realtime_counter += Time.deltaTime;
+
+        while (realtime_counter >= 1f / TicksPerSecond)
+        {
+            Tick();
+            realtime_counter -= 1f / TicksPerSecond;
+        }
+    }
+}

--- a/Assets/Script/game_control/TIckManeger.cs.meta
+++ b/Assets/Script/game_control/TIckManeger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec5bd359f45a32941ad7da9c88a4e133


### PR DESCRIPTION
新增 CreaturePool 靜態類別，利用 Unity ObjectPool 管理 Creature 物件重複利用，提升效能。新增 TickManeger 單例類別，統一管理 Tick 機制並支援註冊/取消 Tick 回呼。包含對應的 .meta 檔案。