### PR TITLE
環境實體管理重構：引入物件池與座標字典

### DIFF
--- a/Assets/Script/Creature/Creature.cs
+++ b/Assets/Script/Creature/Creature.cs
@@ -19,11 +19,11 @@ public partial class Creature : MonoBehaviour, ITickable
 {
     public void OnEnable()
     {
-        Manager.OnTick += OnTick;
+        TickManager.Instance.RegisterTickable(OnTick);
     }
     public void OnDisable()
     {
-        Manager.OnTick -= OnTick;
+        TickManager.Instance.UnregisterTickable(OnTick);
     }
 
     // 防止重複銷毀和訪問已銷毀物件的標記
@@ -70,17 +70,16 @@ public partial class Creature : MonoBehaviour, ITickable
         // 重要：先取消訂閱事件
         OnDisable();
 
-        if (Manager.Instance != null)
+        if (Manager.Instance != null && Manager.Instance.EnvironmentEntities != null)
         {
             // Spawn food item
             GameObject meat_prefab = Resources.Load<GameObject>("Prefabs/Edible/Meat");
-            Instantiate(meat_prefab, transform.position, Quaternion.identity, Manager.Instance.EnvironmentEntities)
-                .GetComponent<Edible>()
-                .Initialize();
-        }
-        else
-        {
-            Debug.LogWarning("MeatPrefab is null");
+            if (meat_prefab != null)
+            {
+                var meatObj = Instantiate(meat_prefab, transform.position, Quaternion.identity, Manager.Instance.EnvironmentEntities);
+                var edible = meatObj.GetComponent<Edible>();
+                edible?.Initialize();
+            }
         }
         
         if (Manager.Instance != null)

--- a/Assets/Script/base/CreaturePool.cs
+++ b/Assets/Script/base/CreaturePool.cs
@@ -222,8 +222,6 @@ public static class CreaturePool
         }
         
         prefab = null;
-        
-        Debug.Log("CreaturePool: Pool cleared.");
     }
 
     /// <summary>
@@ -289,10 +287,7 @@ public static class CreaturePool
     private static void ActionOnRelease(Creature creature)
     {
         if (creature == null) return;
-        
-        // 取消事件訂閱（避免重複訂閱）
-        creature.OnDisable();
-        
+               
         // 停止所有協程
         creature.StopAllCoroutines();
         

--- a/Assets/Script/base/EntityPool.cs
+++ b/Assets/Script/base/EntityPool.cs
@@ -1,0 +1,162 @@
+using UnityEngine;
+using UnityEngine.Pool;
+using System;
+
+public class EntityPool<T> : IEntityPool where T : MonoBehaviour
+{
+    private readonly SpawnableEntity _entityData;
+    private GameObject _prefab;
+    private Transform _poolParent;
+
+    private ObjectPool<T> pool;
+
+    public int CountActive => pool.CountActive;
+    public int CountInactive => pool.CountInactive;
+    public int CountAll => pool.CountAll;
+
+    public EntityPool(EntityData.SpawnableEntityType spawnableType, int defaultCapacity = 1000)
+    {
+        _entityData = EntityData.GetSpawnableEntity(spawnableType);
+
+        EnsureInitialized();
+
+        pool = new ObjectPool<T>(
+            createFunc: CreateEntity,
+            actionOnGet: ActionOnGet,
+            actionOnRelease: ActionOnRelease,
+            actionOnDestroy: ActionOnDestroy,
+            collectionCheck: false,
+            defaultCapacity: defaultCapacity,
+            maxSize: Math.Min(_entityData.MaxSpawnableValue, 100_000)
+        );
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_prefab == null)
+        {
+            _prefab = Resources.Load<GameObject>(_entityData.PrefabPath);
+            if (_prefab == null)
+            {
+                Debug.LogError($"EntityPool<{typeof(T).Name}>: Failed to load prefab from {_entityData.PrefabPath}");
+            }
+        }
+
+        if (_poolParent == null)
+        {
+            GameObject parentObj = new("[" + typeof(T).Name + "Pool]");
+            _poolParent = parentObj.transform;
+            UnityEngine.Object.DontDestroyOnLoad(parentObj);
+        }
+    }
+
+    // 泛型版本（供知道具體類型時使用）
+    public T GetEntityTyped()
+    {
+        EnsureInitialized();
+        return pool.Get();
+    }
+
+    public T GetEntityTyped(Vector2Int position, Transform parent = null)
+    {
+        EnsureInitialized();
+
+        T entity = GetEntityTyped();
+        if (parent != null) entity.transform.SetParent(parent);
+        entity.transform.position = new Vector3(position.x, position.y, 0);
+        return entity;
+    }
+
+    public void ReleaseEntityTyped(T entity)
+    {
+        if (entity != null) pool.Release(entity);
+    }
+
+    // IEntityPool 介面實作（供動態調用時使用）
+    MonoBehaviour IEntityPool.GetEntity()
+    {
+        return GetEntityTyped();
+    }
+
+    MonoBehaviour IEntityPool.GetEntity(Vector2Int position, Transform parent)
+    {
+        return GetEntityTyped(position, parent);
+    }
+
+    void IEntityPool.ReleaseEntity(MonoBehaviour entity)
+    {
+        if (entity is T typedEntity)
+        {
+            ReleaseEntityTyped(typedEntity);
+        }
+        else if (entity != null)
+        {
+            Debug.LogWarning($"EntityPool<{typeof(T).Name}>: Cannot release entity of type {entity.GetType().Name}");
+        }
+    }
+
+    public void ClearPool()
+    {
+        pool.Clear();
+        if (_poolParent != null)
+        {
+            UnityEngine.Object.Destroy(_poolParent.gameObject);
+            _poolParent = null;
+        }
+
+        _prefab = null;
+    }
+
+    private T CreateEntity()
+    {
+        EnsureInitialized();
+
+        if (_prefab == null)
+        {
+            Debug.LogError($"EntityPool<{typeof(T).Name}>: Prefab is null, cannot create entity.");
+            return null;
+        }
+
+        GameObject obj = UnityEngine.Object.Instantiate(_prefab, _poolParent);
+        obj.name = "Pooled" + _prefab.name;
+        obj.SetActive(false);
+
+        T entity = obj.GetComponent<T>();
+        if (entity == null)
+        {
+            Debug.LogError($"EntityPool<{typeof(T).Name}>: Prefab does not contain component of type {typeof(T).Name}");
+            UnityEngine.Object.Destroy(obj);
+            return null;
+        }
+        return entity;
+    }
+
+    private void ActionOnGet(T entity)
+    {
+        if (entity == null) return;
+
+        entity.gameObject.SetActive(true);
+        entity.transform.SetParent(null);
+        entity.transform.localScale = Vector3.one;
+    }
+
+    private void ActionOnRelease(T entity)
+    {
+        if (entity == null) return;
+
+        entity.StopAllCoroutines();
+
+        entity.gameObject.SetActive(false);
+        entity.transform.SetParent(_poolParent);
+        entity.transform.position = Vector3.zero;
+        entity.transform.rotation = Quaternion.identity;
+    }
+
+    private void ActionOnDestroy(T entity)
+    {
+        if (entity != null && entity.gameObject != null)
+        {
+            UnityEngine.Object.Destroy(entity.gameObject);
+        }
+    }
+}

--- a/Assets/Script/base/EntityPool.cs.meta
+++ b/Assets/Script/base/EntityPool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 447eee364681f464d9330c569add3d21

--- a/Assets/Script/base/EnvEntityManager.cs
+++ b/Assets/Script/base/EnvEntityManager.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using Random = UnityEngine.Random;
+
+public class EnvEntityManager : ITickable
+{
+    // ========== ONLY FOR TEMPORARY TESTING ==========
+    // Define spawn range constants (!!BOTH INCLUSIVE!!)
+    private const int MINSPAWNRANGE = 0;
+    private const int MAXSPAWNRANGE = 500;
+    // ========== ONLY FOR TEMPORARY TESTING ==========
+
+    public EnvEntityManager()
+    {
+        Initialize();
+    }
+
+    public Transform EnvironmentEntities { get; private set; }
+
+    // Dictionary to hold entities with their positions (by type)
+    private readonly Dictionary<EntityData.SpawnableEntityType, Dictionary<Vector2Int, GameObject>> _entityDict = new();
+    // Dictionary to hold entity pools (by type)
+    private readonly Dictionary<EntityData.SpawnableEntityType, IEntityPool> _entityPool = new();
+
+    private void Initialize()
+    {
+        GameObject env_entites_prefab = Resources.Load<GameObject>("Prefabs/Parents/EnvironmentEntities");
+        EnvironmentEntities = UnityEngine.Object.Instantiate(env_entites_prefab).transform;
+
+        // Initialize entity dictionaries and pools
+        foreach (EntityData.SpawnableEntityType type in Enum.GetValues(typeof(EntityData.SpawnableEntityType)))
+        {
+            SpawnableEntity entityData = EntityData.GetSpawnableEntity(type);
+            _entityDict.Add(type, new Dictionary<Vector2Int, GameObject>());
+
+            // 使用反射創建正確的泛型池
+            Type poolType = typeof(EntityPool<>).MakeGenericType(entityData.ClassType);
+            IEntityPool poolInstance = (IEntityPool)Activator.CreateInstance(poolType, new object[] { type, 1000});
+            _entityPool.Add(type, poolInstance);
+        }
+    }
+
+    public void OnEnable()
+    {
+        TickManager.Instance.RegisterTickable(OnTick);
+    }
+
+    public void OnDisable()
+    {
+        TickManager.Instance.UnregisterTickable(OnTick);
+    }
+
+    public void OnTick()
+    {
+        RandomlySpawnEntity(EntityData.SpawnableEntityType.Grass);
+    }
+
+    /// <summary>
+    /// 取得指定類型的實體數量
+    /// </summary>
+    public int GetEntityCount(EntityData.SpawnableEntityType type)
+    {
+        if (_entityDict.TryGetValue(type, out var dict))
+        {
+            return dict.Count;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// 取得指定類型的實體池
+    /// </summary>
+    public IEntityPool GetPool(EntityData.SpawnableEntityType type)
+    {
+        if (_entityPool.TryGetValue(type, out var pool))
+        {
+            return pool;
+        }
+        return null;
+    }
+
+    private void RandomlySpawnEntity(EntityData.SpawnableEntityType spawnableType)
+    {
+        SpawnableEntity entityData = EntityData.GetSpawnableEntity(spawnableType);
+        
+        // 檢查是否達到最大數量限制
+        if (GetEntityCount(spawnableType) >= entityData.MaxSpawnableValue) return;
+
+        Vector2Int position = new Vector2Int(
+            Random.Range(MINSPAWNRANGE, MAXSPAWNRANGE + 1),
+            Random.Range(MINSPAWNRANGE, MAXSPAWNRANGE + 1)
+        );
+
+        // Check if position is occupied
+        if (_entityDict[spawnableType].ContainsKey(position)) return;
+
+        // Check terrain type
+        var random_positions = GetRandomPosition(position, 3, Random.Range(1, 5));
+        foreach (var pos in random_positions)
+        {
+            SpawnEntity(spawnableType, pos);
+        }
+    }
+
+    private List<Vector2Int> GetRandomPosition(Vector2Int position, int r, int n)
+    {
+        List<Vector2Int> positions = new();
+        HashSet<Vector2Int> used_position = new();
+        uint tries = 0;
+        while (positions.Count < n && tries < n * 10)
+        {
+            float angle = Random.Range(0f, 360f);
+            float radius = Random.Range(0f, r);
+            Vector2Int new_position = position + new Vector2Int(
+                Mathf.RoundToInt(radius * Mathf.Cos(angle * Mathf.Deg2Rad)),
+                Mathf.RoundToInt(radius * Mathf.Sin(angle * Mathf.Deg2Rad))
+            );
+            if (!used_position.Contains(new_position))
+            {
+                used_position.Add(new_position);
+                positions.Add(new_position);
+            }
+            tries++;
+        }
+        return positions;
+    }
+
+    /// <summary>
+    /// 在指定位置生成實體
+    /// </summary>
+    /// <returns>是否成功生成</returns>
+    public bool SpawnEntity(EntityData.SpawnableEntityType spawnableType, Vector2Int pos)
+    {
+        // 檢查位置是否已被佔用
+        if (_entityDict[spawnableType].ContainsKey(pos)) return false;
+
+        SpawnableEntity entityData = EntityData.GetSpawnableEntity(spawnableType);
+
+        // 檢查地形是否允許生成
+        if (entityData.SpawnableTerrain != null && entityData.SpawnableTerrain.Count > 0)
+        {
+            TerrainType currentTerrain = TerrainGenerator.Instance.GetDefinitionMap().GetTerrain(pos);
+            bool canSpawn = false;
+            foreach (var terrainType in entityData.SpawnableTerrain)
+            {
+                if (currentTerrain == terrainType)
+                {
+                    canSpawn = true;
+                    break;
+                }
+            }
+            if (!canSpawn) return false;
+        }
+
+        // 從物件池取得實體
+        MonoBehaviour entity = _entityPool[spawnableType].GetEntity(pos, EnvironmentEntities);
+        if (entity == null) return false;
+
+        // 記錄到字典中
+        _entityDict[spawnableType].Add(pos, entity.gameObject);
+
+        // 如果實體有 Initialize 方法，呼叫它
+        if (entity is Edible edible)
+        {
+            edible.Initialize();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 移除指定位置的實體並回收到物件池
+    /// </summary>
+    public bool RemoveEntity(EntityData.SpawnableEntityType spawnableType, Vector2Int pos)
+    {
+        if (!_entityDict[spawnableType].TryGetValue(pos, out GameObject entityObj))
+        {
+            return false;
+        }
+
+        // 從字典中移除
+        _entityDict[spawnableType].Remove(pos);
+
+        // 回收到物件池
+        MonoBehaviour entity = entityObj.GetComponent<MonoBehaviour>();
+        if (entity != null)
+        {
+            _entityPool[spawnableType].ReleaseEntity(entity);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 取得指定位置的實體
+    /// </summary>
+    public T GetEntity<T>(EntityData.SpawnableEntityType spawnableType, Vector2Int position) where T : MonoBehaviour
+    {
+        if (_entityDict.TryGetValue(spawnableType, out var entityPositions))
+        {
+            if (entityPositions.TryGetValue(position, out var entityObj))
+            {
+                return entityObj.GetComponent<T>();
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 清空所有實體並清理物件池
+    /// </summary>
+    public void ClearAll()
+    {
+        foreach (var type in _entityDict.Keys)
+        {
+            _entityDict[type].Clear();
+            _entityPool[type].ClearPool();
+        }
+    }
+}

--- a/Assets/Script/base/EnvEntityManager.cs.meta
+++ b/Assets/Script/base/EnvEntityManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec1bc855621ebbc408701e923fea117a

--- a/Assets/Script/base/IEntityPool.cs
+++ b/Assets/Script/base/IEntityPool.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public interface IEntityPool
+{
+    int CountActive { get; }
+    int CountInactive { get; }
+    int CountAll { get; }
+
+    MonoBehaviour GetEntity();
+    MonoBehaviour GetEntity(Vector2Int position, Transform parent = null);
+    void ReleaseEntity(MonoBehaviour entity);
+    void ClearPool();
+}

--- a/Assets/Script/base/IEntityPool.cs.meta
+++ b/Assets/Script/base/IEntityPool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 510cbb5e5924ae046bcc9c1ac555063d

--- a/Assets/Script/base/Manager.cs
+++ b/Assets/Script/base/Manager.cs
@@ -1,18 +1,20 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 public class Manager : MonoBehaviour
 {
+    // Singleton instance
     public static Manager Instance { get; private set; }
+    // List of all species in the simulation
     [SerializeField]
     private readonly List<Species> species = new();
     public List<Species> Species => species;
-    [SerializeField]
-    private readonly Dictionary<Vector2Int, Edible> fooditems = new();
-    public Dictionary<Vector2Int, Edible> FoodItems => fooditems;
-    public static event System.Action OnTick;
-    public Transform EnvironmentEntities { get; private set; }
+    // Initialize the EnvEntityManager
+    public EnvEntityManager EnvEntityManager { get; private set; }
+
+    // 便利屬性：提供對 EnvironmentEntities 的訪問
+    public Transform EnvironmentEntities => EnvEntityManager?.EnvironmentEntities;
+
     void Start()
     {
         Initialize();
@@ -28,39 +30,26 @@ public class Manager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+        
+        // 在 Awake 中初始化 EnvEntityManager，確保在其他腳本的 Start 之前可用
+        EnvEntityManager = new EnvEntityManager();
     }
     private void Initialize()
     {
+        // Ensure TickManager exists
         if (TickManager.Instance == null)
         {
             new GameObject("TickManager").AddComponent<TickManager>();
         }
-
-        TickManager.Instance.RegisterTickable(() =>
-        {
-            OnTick?.Invoke();
-        });
-
-        TickManager.Instance.RegisterTickable(SpawnEdible);
-
-        GameObject env_entites_prefab = Resources.Load<GameObject>("Prefabs/Parents/EnvironmentEntities");
-        EnvironmentEntities = Instantiate(env_entites_prefab).transform;
+        
+        // 啟用 EnvEntityManager 的 Tick 訂閱
+        EnvEntityManager?.OnEnable();
     }
 
-    private void OnDestroy()
-    {
-        TickManager.Instance?.UnregisterTickable(SpawnEdible);
-    }
-
-    private void OnEnable()
-    {
-        OnTick += SpawnEdible;
-    }
     private void OnDisable()
     {
-        OnTick -= SpawnEdible;
+        EnvEntityManager?.OnDisable();
     }
-
 
     private void PredatorUpdate(Creature new_creature)
     {
@@ -159,61 +148,5 @@ public class Manager : MonoBehaviour
         //        Debug.Log($"族群 {s.attributes.species_ID} 生物 {c.UUID}");
         //    }
         //}
-    }
-    // spawn the edible item
-    private void SpawnEdible()
-    {
-        //Debug.Log("grass num: "+FoodItems.Count);
-        //TODO: Const of max food items and map size
-        // Limit the number of food items
-        if (fooditems.Count > 4000) return;
-
-        Vector2Int position = new Vector2Int(
-            Random.Range(100, 400),
-            Random.Range(100, 400)
-        );
-        // Check if position is occupied
-        if (fooditems.ContainsKey(position)) return;
-        // Check terrain type
-        var random_positions = GetRandomPosition(position, 3, Random.Range(1, 5));
-        foreach (var pos in random_positions)
-        {
-            //Debug.Log("Trying to spawn food at: " + pos);
-            //Debug.Log("Terrain at pos: " + TerrainGenerator.Instance.GetDefinitionMap().GetTerrain(pos));
-            if (fooditems.ContainsKey(pos)) continue;
-            if (TerrainGenerator.Instance.GetDefinitionMap().GetTerrain(pos) != TerrainType.Grass) continue;
-            Vector3 pos3 = new Vector3(pos.x, pos.y, 0f);
-            // Spawn food item
-            GameObject food_item_prefab = Resources.Load<GameObject>("Prefabs/Edible/Grass");
-            GameObject food_item_object = Instantiate(food_item_prefab, pos3, Quaternion.identity,EnvironmentEntities);
-            Edible food_item = food_item_object.GetComponent<Edible>();
-            fooditems.Add(pos, food_item);
-            food_item.Initialize();
-
-        }
-
-    }
-
-    private List<Vector2Int> GetRandomPosition(Vector2Int position, int r, int n)
-    {
-        List<Vector2Int> position_ = new();
-        HashSet<Vector2Int> used_position = new();
-        uint tries = 0;
-        while (position_.Count < n && tries < n * 10)
-        {
-            float angle = Random.Range(0f, 360f);
-            float radius = Random.Range(0f, r);
-            Vector2Int new_position = position + new Vector2Int(
-                Mathf.RoundToInt(radius * Mathf.Cos(angle * Mathf.Deg2Rad)),
-                Mathf.RoundToInt(radius * Mathf.Sin(angle * Mathf.Deg2Rad))
-            );
-            if (!used_position.Contains(new_position))
-            {
-                used_position.Add(new_position);
-                position_.Add(new_position);
-            }
-            tries++;
-        }
-        return position_;
     }
 }

--- a/Assets/Script/data/EntityData.cs
+++ b/Assets/Script/data/EntityData.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+// This static class holds data related to various entities that can be spawned in the environment
+public static class EntityData
+{
+    public enum SpawnableEntityType
+    {
+        Grass,
+        Meat,
+        Carrion
+    }
+
+    private static readonly Dictionary<SpawnableEntityType, SpawnableEntity> spawnableDict = new()
+    {
+        { SpawnableEntityType.Grass, new SpawnableEntity(typeof(Grass), "Prefabs/Edible/Grass", 5000, FoodType.Grass, new List<TerrainType> { TerrainType.Grass }) },
+        { SpawnableEntityType.Meat, new SpawnableEntity(typeof(Meat), "Prefabs/Edible/Meat", int.MaxValue, FoodType.Meat) },
+        { SpawnableEntityType.Carrion, new SpawnableEntity(typeof(Carrion), "Prefabs/Edible/Carrion", int.MaxValue, FoodType.Carrion) }
+    };
+
+    private static readonly Dictionary<FoodType, SpawnableEntityType> foodTypeMapping = new()
+    {
+        { FoodType.Grass, SpawnableEntityType.Grass },
+        { FoodType.Meat, SpawnableEntityType.Meat },
+        { FoodType.Carrion, SpawnableEntityType.Carrion }
+    };
+
+    public static SpawnableEntityType? FoodType2SpawnableType(FoodType foodType)
+    {
+        if (foodTypeMapping.TryGetValue(foodType, out var spawnableType))
+        {
+            return spawnableType;
+        }
+        return null;
+    }
+
+    public static FoodType? SpawnableType2FoodType(SpawnableEntityType spawnableType)
+    {
+        if (spawnableDict.TryGetValue(spawnableType, out var entity))
+        {
+            return entity.FoodType;
+        }
+        return null;
+    }
+
+    public static SpawnableEntity GetSpawnableEntity(SpawnableEntityType spawnableType)
+    {
+        if (spawnableDict.TryGetValue(spawnableType, out var entity))
+        {
+            return entity;
+        }
+        return null;
+    }
+
+    // Chech the Dictionary and the enum match
+    static EntityData()
+    {
+        if (spawnableDict.Count != System.Enum.GetValues(typeof(SpawnableEntityType)).Length)
+        {
+            Debug.LogError("spawnableDict count does not match SpawnableEntityType enum count.");
+            foreach (SpawnableEntityType type in System.Enum.GetValues(typeof(SpawnableEntityType)))
+            {
+                if (!spawnableDict.ContainsKey(type))
+                {
+                    Debug.LogError($"SpawnableEntityType {type} is not defined in spawnableDict.");
+                }
+            }
+        }
+    }
+}
+
+// This class is used for safe-keeping data related to spawnable entities
+// Represents an entity that can be spawned in the environment
+public class SpawnableEntity
+{
+    public Type ClassType { get; private set; }
+    // The path to the prefab resource
+    public string PrefabPath { get; }
+    // Indicates whether the entity can be spawned
+    public List<TerrainType> SpawnableTerrain { get; private set; }
+    public int MaxSpawnableValue { get; private set; }
+    public FoodType? FoodType { get; private set; }
+
+    public SpawnableEntity(Type type, string prefabPath, int maxVal, FoodType? foodType = null, List<TerrainType> spawnableTerrain = null)
+    {
+        ClassType = type;
+        PrefabPath = prefabPath;
+        MaxSpawnableValue = maxVal;
+        FoodType = foodType;
+        // If no specific terrain is provided, it can be spawned on any terrain
+        SpawnableTerrain = spawnableTerrain;
+    }
+}
+

--- a/Assets/Script/data/EntityData.cs.meta
+++ b/Assets/Script/data/EntityData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7290902e6c44a1743bd71eee96decc02

--- a/Assets/Script/food/Carrion.cs
+++ b/Assets/Script/food/Carrion.cs
@@ -5,4 +5,9 @@ public class Carrion : Edible
     public override int LifeSpan { get; protected set; } = 100;
     public override float NutritionalValue => 20f;
 	public override FoodType Type => FoodType.Carrion;
+
+    protected override EntityData.SpawnableEntityType GetEntityType()
+    {
+        return EntityData.SpawnableEntityType.Carrion;
+    }
 }

--- a/Assets/Script/food/Grass.cs
+++ b/Assets/Script/food/Grass.cs
@@ -4,8 +4,13 @@ public class Grass : Edible
 {
     [SerializeField]
     public override int LifeSpan { get; protected set; } = 50000;
-    [SerializeField] 
+    [SerializeField]
     public override float NutritionalValue => 50f;
-    [SerializeField] 
+    [SerializeField]
     public override FoodType Type => FoodType.Grass;
+
+    protected override EntityData.SpawnableEntityType GetEntityType()
+    {
+        return EntityData.SpawnableEntityType.Grass;
+    }
 }

--- a/Assets/Script/food/Meat.cs
+++ b/Assets/Script/food/Meat.cs
@@ -6,4 +6,8 @@ public class Meat : Edible
     public override float NutritionalValue => 30f;
     public override FoodType Type => FoodType.Meat;
 
+    protected override EntityData.SpawnableEntityType GetEntityType()
+    {
+        return EntityData.SpawnableEntityType.Meat;
+    }
 }

--- a/Assets/Script/game_control/TickManager.cs
+++ b/Assets/Script/game_control/TickManager.cs
@@ -7,7 +7,8 @@ public class TickManager: MonoBehaviour
     public static TickManager Instance { get; private set; }
     public int CurrentHour { get; private set; }
     public int CurrentDay { get; private set; }
-    public TickManager()
+
+    private void Awake()
     {
         if (Instance != null && Instance != this)
         {
@@ -15,6 +16,7 @@ public class TickManager: MonoBehaviour
             return;
         }
         Instance = this;
+        DontDestroyOnLoad(gameObject);
     }
 
     private readonly List<Action> tickable = new(); 
@@ -45,7 +47,10 @@ public class TickManager: MonoBehaviour
         CurrentHour = total_hours % constantData.HOURS_PER_DAY;
         CurrentDay = (total_hours / constantData.HOURS_PER_DAY) + 1;
 
-        foreach (var t in tickable)
+        // Create a copy of the list to avoid modification during iteration
+        var tickOnTime = new List<Action>(tickable);
+
+        foreach (var t in tickOnTime)
         {
             t?.Invoke();
         }


### PR DESCRIPTION
重構環境實體（草、肉、屍體等）管理，新增 EntityData、IEntityPool、EntityPool<T> 與 EnvEntityManager，統一以座標為 key 管理生成、查詢與回收。Manager 移除 FoodItems 與舊有生成邏輯，改用 EnvEntityManager。Edible 及其子類配合新架構調整，感知系統（Perception）全面改為座標查詢。TickManager 迴圈安全性提升。新增相關 .meta 檔。