### PR TITLE
重構 Creature 屬性管理並導入 Attribute 系統

### DIFF
--- a/Assets/Scenes/yu_Scene.unity
+++ b/Assets/Scenes/yu_Scene.unity
@@ -231,9 +231,9 @@ GameObject:
   m_Component:
   - component: {fileID: 244281955}
   - component: {fileID: 244281954}
-  - component: {fileID: 244281953}
   - component: {fileID: 244281956}
   - component: {fileID: 244281957}
+  - component: {fileID: 244281958}
   m_Layer: 0
   m_Name: Manager
   m_TagString: Untagged
@@ -241,18 +241,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &244281953
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 244281952}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4502c7a75c432c849af7ec6b497d512f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::Manager
 --- !u!114 &244281954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -315,6 +303,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::TimeClock
   textUI: {fileID: 1245546172}
+--- !u!114 &244281958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244281952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a7a95ce7c0e2974fab67304542822b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MainManager
 --- !u!1 &357938609
 GameObject:
   m_ObjectHideFlags: 0
@@ -479,6 +479,7 @@ Tilemap:
     e33: 1
 --- !u!483693784 &375739567
 TilemapRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -524,6 +525,7 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 2
+  m_MaskInteraction: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -531,7 +533,6 @@ TilemapRenderer:
   m_SortOrder: 0
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
 --- !u!4 &375739568
 Transform:
   m_ObjectHideFlags: 0
@@ -567,6 +568,7 @@ GameObject:
   m_IsActive: 1
 --- !u!212 &423214106
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -612,6 +614,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 10
+  m_MaskInteraction: 0
   m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
   m_Color: {r: 0.34325653, g: 0.041374087, b: 0.5622641, a: 1}
   m_FlipX: 0
@@ -621,7 +624,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &423214107
 Transform:
@@ -935,6 +937,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1042,6 +1045,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!483693784 &1487250907
 TilemapRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1087,6 +1091,7 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -1094,7 +1099,6 @@ TilemapRenderer:
   m_SortOrder: 0
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
 --- !u!1839735485 &1487250908
 Tilemap:
   m_ObjectHideFlags: 0
@@ -1171,6 +1175,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!483693784 &1545182174
 TilemapRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1216,6 +1221,7 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -1223,7 +1229,6 @@ TilemapRenderer:
   m_SortOrder: 0
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
 --- !u!1839735485 &1545182175
 Tilemap:
   m_ObjectHideFlags: 0
@@ -1297,6 +1302,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!483693784 &1617259331
 TilemapRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1342,6 +1348,7 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
+  m_MaskInteraction: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -1349,7 +1356,6 @@ TilemapRenderer:
   m_SortOrder: 0
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
 --- !u!1839735485 &1617259332
 Tilemap:
   m_ObjectHideFlags: 0
@@ -1423,6 +1429,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!483693784 &1899265547
 TilemapRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1468,6 +1475,7 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -1475,7 +1483,6 @@ TilemapRenderer:
   m_SortOrder: 0
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
-  m_MaskInteraction: 0
 --- !u!1839735485 &1899265548
 Tilemap:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Creature/Creature.Data.cs
+++ b/Assets/Script/Creature/Creature.Data.cs
@@ -5,6 +5,20 @@ using static Perception;
 
 public partial class Creature : MonoBehaviour, ITickable
 {
+    //TODO: 這邊的屬性可以用Attribute包裝，然後用Dictionary<ActionType, Attribute>來管理
+    public List<int> preyIDList => mySpecies.preyIDList;
+    public List<int> predatorIDList => mySpecies.predatorIDList;
+    public List<FoodType> foodTypes => mySpecies.foodTypes;
+    public float attackPower { get; private set; }
+    public bool isSleeping { get; private set; } = false;
+    public Creature enemy { get; private set; }
+    public CreatureMovementState movementState { get; private set; }
+    public Gender gender;
+    //public Creature matingPartner; // 目前鎖定的配對對象
+    public float reproductionCD; // 成功繁殖的冷卻
+    public string fatherID { get; private set; }
+    public string motherID { get; private set; }
+
     //TODO: 把各種屬性包含運行中的數據包裝成DTO像是ToCreatureAttribute()類似
     //TODO: Design Pattern: Strategy Pattern、State Pattern
     public Species mySpecies;
@@ -15,19 +29,17 @@ public partial class Creature : MonoBehaviour, ITickable
     //TODO: lambda表達式有辦法設定get set嗎？這樣感覺有點危險
     public int speciesID => mySpecies.speciesID;
     public CreatureBase creatureBase => mySpecies.creatureBase;
-    public List<int> preyIDList => mySpecies.preyIDList;
-    public List<int> predatorIDList => mySpecies.predatorIDList;
+
     public List<ActionType> actionList => mySpecies.actionList;
-    public List<FoodType> foodTypes => mySpecies.foodTypes;
     public Dictionary<ActionType, int> actionMaxCD => mySpecies.actionMaxCD;
     public float variation => mySpecies.variation;
+
 
     // --- 個體遺傳屬性 ---
     public float size { get; private set; }
     public float speed { get; private set; }
     public float maxHealth { get; private set; }
     public float reproductionRate { get; private set; }
-    public float attackPower { get; private set; }
     public float lifespan { get; private set; }
     public float perceptionRange { get; private set; }
     //public int sleepingHead { get; private set; }
@@ -44,7 +56,6 @@ public partial class Creature : MonoBehaviour, ITickable
     public float age { get; private set; }
     public int actionCooldown { get; private set; }
     public float stunTimer { get; private set; } = 0f;
-    public bool isSleeping { get; private set; } = false;
     public bool isDead { get; private set; } = false;
     public bool isInvincible { get; private set; } = false;
     public bool isStunned { get; private set; } = false;
@@ -53,13 +64,8 @@ public partial class Creature : MonoBehaviour, ITickable
     public Direction underAttackDirection { get; private set; }
     public LifeState currentLifeState { get; private set; }
     public Dictionary<ActionType, int> actionCD { get; private set; } = new();
-    public Creature enemy { get; private set; }
-    public CreatureMovementState movementState { get; private set; }
-    public Gender gender;
-    //public Creature matingPartner; // 目前鎖定的配對對象
-    public float reproductionCD; // 成功繁殖的冷卻
-    public string fatherID { get; private set; }
-    public string motherID { get; private set; }
+
+    // ===================================包一包==================================
     // 儲存六色比例，和必須為 1
     // 索引：0:紅, 1:橙, 2:黃, 3:綠, 4:藍, 5:紫
     public float[] colorGenes = new float[6];
@@ -83,6 +89,6 @@ public partial class Creature : MonoBehaviour, ITickable
     // 強烈建議：將所有生物放在同一個 Layer (例如 "Creature")
     // 這樣 Physics2D 就不會去掃描地形或其他無關的物件
     public LayerMask creatureLayer;
+    // ========================================================================
+
 }
-
-

--- a/Assets/Script/action/Attributes.meta
+++ b/Assets/Script/action/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f35d1a935e5957448e0c507f6814c7b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/action/Attributes/BoolAttribute.cs
+++ b/Assets/Script/action/Attributes/BoolAttribute.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class BoolAttribute : IValueAttribute<bool>
+{
+    private bool _value;
+
+    public bool Query()
+    {
+        return _value;
+    }
+
+    public bool Set(bool newValue)
+    {
+        _value = newValue;
+        return true;
+    }
+
+    public BoolAttribute(bool initialValue)
+    {
+        _value = initialValue;
+    }
+}

--- a/Assets/Script/action/Attributes/BoolAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/BoolAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62b50f47cc6f81c488c075213ffc5345

--- a/Assets/Script/action/Attributes/Concrete.meta
+++ b/Assets/Script/action/Attributes/Concrete.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae00a48b2dc5a174eb003df9dbc413dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/action/Attributes/Concrete/AttackPowerAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/AttackPowerAttr.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class AttackPowerAttr : FloatAttribute
+
+{
+    public AttackPowerAttr(float initialValue, float multiplier = 1) : base(initialValue, multiplier)
+    {
+    }
+
+    protected override void Validate()
+    {
+        if (_baseValue < 0)
+        {
+            LogManager.LogWarning("Attack value cannot be negative. Setting to 0.");
+            _baseValue = 0;
+        }
+
+        if (_multiplier < 0)
+        {
+            LogManager.LogWarning("Attack multiplier cannot be negative. Setting to 0.");
+            _multiplier = 0;
+        }
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/AttackPowerAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/AttackPowerAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef3ea3bb944881a408a23d6644347a93

--- a/Assets/Script/action/Attributes/Concrete/ColorAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/ColorAttr.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+public class ColorAttr : IAttribute
+{
+    // TODO: 這邊不知道要有什麼檢查，所以先不做任何檢查，而且都給 public，以後記得改
+
+    // 儲存六色比例，和必須為 1
+    // 索引：0:紅, 1:橙, 2:黃, 3:綠, 4:藍, 5:紫
+    public float[] colorGenes { get; set; } = new float[4];
+
+    // 狀態判定
+    public bool isWandering { get; set; } = false;
+    public float fadeSpeed { get; set; } = 0.1f; // 褪色速度
+    public bool isUsingColorGenes { get; set; } = true; // 是否啟用顏色基因影響外觀
+    // 渲染相關
+    public Renderer myRenderer { get; set; }
+    public MaterialPropertyBlock propBlock { get; set; }
+
+    [Header("Wandering Detection")]
+    public float checkInterval { get; set; } = 1.0f;     // 判斷頻率：每 1 秒判斷一次即可
+    public float _checkTimer { get; set; } = 0f;
+
+    public float detectionRadius { get; set; } = 15.0f;   // 感應範圍
+    public int minFamilyNeighbors { get; set; } = 1;     // 至少需要幾個「相似」同伴才不算走散
+    public float similarityThreshold { get; set; } = 0.8f; // 基因差異容忍度 (數值越小，判斷越嚴格)
+
+    // 強烈建議：將所有生物放在同一個 Layer (例如 "Creature")
+    // 這樣 Physics2D 就不會去掃描地形或其他無關的物件
+    public LayerMask creatureLayer { get; set; }
+}

--- a/Assets/Script/action/Attributes/Concrete/ColorAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/ColorAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 426bde1ccbc2e764a98ceab36046064a

--- a/Assets/Script/action/Attributes/Concrete/EnemyAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/EnemyAttr.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+
+//   原本是存Creature，感覺不應該存Creautre 應該存UUID
+public class EnemyAttr : StringAttribute
+{
+    public EnemyAttr(string initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/EnemyAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/EnemyAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a939281a5ba1dd47a0a27e6865e9177

--- a/Assets/Script/action/Attributes/Concrete/FatherIdAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/FatherIdAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class FatherIdAttr : StringAttribute
+{
+    public FatherIdAttr(string initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/FatherIdAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/FatherIdAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0690ab65b5684e4eacf6a7d6f10529b

--- a/Assets/Script/action/Attributes/Concrete/FoodTypesAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/FoodTypesAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class FoodTypesAttr : ListAttribute<FoodType>
+{
+    public FoodTypesAttr() : base()
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/FoodTypesAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/FoodTypesAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 35bc321481a231541bd53e280569c3bf

--- a/Assets/Script/action/Attributes/Concrete/GenderAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/GenderAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class GenderAttr : EnumAttribute<Gender>
+{
+    public GenderAttr(Gender initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/GenderAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/GenderAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ac06fcf9dc35bf047bfd353a13865f59

--- a/Assets/Script/action/Attributes/Concrete/IsSleepingAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/IsSleepingAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class IsSleepingAttr : BoolAttribute
+{
+    public IsSleepingAttr(bool initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/IsSleepingAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/IsSleepingAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fae15cd89ede6e6408eb328fbbb70972

--- a/Assets/Script/action/Attributes/Concrete/MotherIdAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/MotherIdAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class MotherIdAttr : StringAttribute
+{
+    public MotherIdAttr(string initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/MotherIdAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/MotherIdAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e667cb592b0b863498e355c4381b42a5

--- a/Assets/Script/action/Attributes/Concrete/MovementStateAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/MovementStateAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class MovementStateAttr : EnumAttribute<CreatureMovementState>
+{
+    public MovementStateAttr(CreatureMovementState initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/MovementStateAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/MovementStateAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db104c29fb4f28d4693c987773838c40

--- a/Assets/Script/action/Attributes/Concrete/PredatorIdListAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/PredatorIdListAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class PredatorIdListAttr : ListAttribute<int>
+{
+    public PredatorIdListAttr() : base()
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/PredatorIdListAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/PredatorIdListAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97992c6a6e2654f45a233e3aeb69ce73

--- a/Assets/Script/action/Attributes/Concrete/PreyIdListAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/PreyIdListAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class PreyIdListAttr : ListAttribute<int>
+{
+    public PreyIdListAttr() : base()
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/PreyIdListAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/PreyIdListAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7457980ffd1c76149872b7f375318a2d

--- a/Assets/Script/action/Attributes/Concrete/ReproductionCdAttr.cs
+++ b/Assets/Script/action/Attributes/Concrete/ReproductionCdAttr.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public class ReproductionCdAttr : FloatAttribute
+{
+    public ReproductionCdAttr(float initialValue) : base(initialValue)
+    {
+    }
+}

--- a/Assets/Script/action/Attributes/Concrete/ReproductionCdAttr.cs.meta
+++ b/Assets/Script/action/Attributes/Concrete/ReproductionCdAttr.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6c3d4977df1abc4282f5523665afb2a

--- a/Assets/Script/action/Attributes/DictionaryAttribute.cs
+++ b/Assets/Script/action/Attributes/DictionaryAttribute.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DictionaryAttribute<TKey, TValue> : IValueAttribute<IReadOnlyDictionary<TKey, TValue>>
+{
+    private readonly Dictionary<TKey, TValue> _value;
+
+    public IReadOnlyDictionary<TKey, TValue> Query()
+    {
+        return _value;
+    }
+
+    public DictionaryAttribute(int initialCapacity = 0)
+    {
+        _value = new Dictionary<TKey, TValue>(initialCapacity);
+    }
+
+    public DictionaryAttribute(Dictionary<TKey, TValue> initialValue)
+    {
+        _value = new Dictionary<TKey, TValue>(initialValue);
+    }
+
+    // Encapsulated method to safely add items without duplicates
+    public virtual bool AddItem(TKey key, TValue value)
+    {
+        if (!_value.ContainsKey(key))
+        {
+            _value.Add(key, value);
+            OnItemAdded(key, value);
+            return true;
+        }
+        return false; // Item already exists
+    }
+
+    // Encapsulated method to safely remove items
+    public virtual bool RemoveItem(TKey key)
+    {
+        if (_value.Remove(key))
+        {
+            OnItemRemoved(key);
+            return true;
+        }
+        return false; // Item not found
+    }
+
+    // Encapsulated method to query state
+    public virtual bool HasItem(TKey key)
+    {
+        return _value.ContainsKey(key);
+    }
+
+    public virtual void Clear()
+    {
+        _value.Clear();
+    }
+
+    // Lifecycle hooks for subclasses to override (e.g., triggering events or validations)
+    protected virtual void OnItemAdded(TKey key, TValue value) { }
+    protected virtual void OnItemRemoved(TKey key) { }
+}

--- a/Assets/Script/action/Attributes/DictionaryAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/DictionaryAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c838ad4c5938c54482d27764430509a

--- a/Assets/Script/action/Attributes/EnumAttribute.cs
+++ b/Assets/Script/action/Attributes/EnumAttribute.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class EnumAttribute<TItem> : IValueAttribute<TItem> where TItem : System.Enum
+{
+    private TItem _value;
+
+    public TItem Query()
+    { 
+        return _value; 
+    }
+
+    public bool Set(TItem newValue)
+    {
+        _value = newValue;
+        return true;
+    }
+
+    public EnumAttribute(TItem initialValue)
+    {
+        _value = initialValue;
+    }
+}

--- a/Assets/Script/action/Attributes/EnumAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/EnumAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b376fa2e163b3544a12bcdd7979d0c9

--- a/Assets/Script/action/Attributes/FloatAttribute.cs
+++ b/Assets/Script/action/Attributes/FloatAttribute.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public abstract class FloatAttribute : MathAttribute<float>
+{
+    protected FloatAttribute(float initialValue, float multiplier = 1) : base(initialValue, multiplier)
+    {
+    }
+
+    protected override float PerformAdd(float a, float b) => a + b;
+    protected override float PerformSubtract(float a, float b) => a - b;
+    protected override float PerformMultiply(float a, float b) => a * b;
+    protected override float PerformDivide(float a, float b)
+    {
+        if (Mathf.Approximately(b, 0f))
+        {
+            LogManager.LogWarning("Attempted to divide by zero. Returning the original value.");
+            return a; // Return the original value if division by zero is attempted
+        }
+        return a / b;
+    }
+
+    protected override float CalculateFinalValue()
+    {
+        return _baseValue * _multiplier;
+    }
+}

--- a/Assets/Script/action/Attributes/FloatAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/FloatAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2a48d33b60af80439918662b34f96cc

--- a/Assets/Script/action/Attributes/IAttribute.cs
+++ b/Assets/Script/action/Attributes/IAttribute.cs
@@ -1,0 +1,4 @@
+using UnityEngine;
+
+// Base interface for all attribute (Marker Interface)
+public interface IAttribute { }

--- a/Assets/Script/action/Attributes/IAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/IAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c7cdd291ba204049b428738bb4665f9

--- a/Assets/Script/action/Attributes/IValueAttribute.cs
+++ b/Assets/Script/action/Attributes/IValueAttribute.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface IValueAttribute<T> : IAttribute
+{
+    T Query();
+}

--- a/Assets/Script/action/Attributes/IValueAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/IValueAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c6f3745cf3a26c44af2fc0c92b120d8

--- a/Assets/Script/action/Attributes/IntAttribute.cs
+++ b/Assets/Script/action/Attributes/IntAttribute.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public abstract class IntAttribute : MathAttribute<int>
+{
+    protected IntAttribute(int initialValue, float multiplier = 1) : base(initialValue, multiplier)
+    {
+    }
+
+    protected override int PerformAdd(int a, int b) => a + b;
+    protected override int PerformSubtract(int a, int b) => a - b;
+    protected override int PerformMultiply(int a, int b) => a * b;
+    protected override int PerformDivide(int a, int b)
+    {
+        if (b == 0)
+        {
+            LogManager.LogWarning("Attempted to divide by zero. Returning the original value.");
+            return a; // Return the original value if division by zero is attempted
+        }
+        return a / b;
+    }
+    protected override int CalculateFinalValue()
+    {
+        // Handle double to int conversion safely (e.g., Mathf.RoundToInt)
+        return Mathf.RoundToInt(_baseValue * _multiplier);
+    }
+}

--- a/Assets/Script/action/Attributes/IntAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/IntAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75e85207599a28b42a2a7c55179f8921

--- a/Assets/Script/action/Attributes/ListAttribute.cs
+++ b/Assets/Script/action/Attributes/ListAttribute.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public abstract class ListAttribute<TItem> : IValueAttribute<IReadOnlyList<TItem>>
+{
+    private readonly List<TItem> _items;
+
+    public IReadOnlyList<TItem> Query()
+    {
+        return _items;
+    }
+
+    public ListAttribute(int initialCapacity = 0)
+    {
+        _items = new List<TItem>(initialCapacity);
+    }
+    public ListAttribute(List<TItem> initialValue)
+    {
+        _items = new List<TItem>(initialValue);
+    }
+
+    // Encapsulated method to safely add items without duplicates
+    public virtual bool AddItem(TItem item)
+    {
+        if (!_items.Contains(item))
+        {
+            _items.Add(item);
+            OnItemAdded(item);
+            return true;
+        }
+        return false; // Item already exists
+    }
+
+    // Encapsulated method to safely remove items
+    public virtual bool RemoveItem(TItem item)
+    {
+        if (_items.Remove(item))
+        {
+            OnItemRemoved(item);
+            return true;
+        }
+        return false; // Item not found
+    }
+
+    // Encapsulated method to query state
+    public virtual bool HasItem(TItem item)
+    {
+        return _items.Contains(item);
+    }
+
+    public virtual void Clear()
+    {
+        _items.Clear();
+    }
+
+    // Lifecycle hooks for subclasses to override (e.g., triggering events or validations)
+    protected virtual void OnItemAdded(TItem item) { }
+    protected virtual void OnItemRemoved(TItem item) { }
+}

--- a/Assets/Script/action/Attributes/ListAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/ListAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 716410383bb20504cab6610859df7954

--- a/Assets/Script/action/Attributes/MathAttribute.cs
+++ b/Assets/Script/action/Attributes/MathAttribute.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+public abstract class MathAttribute<T> : IAttribute where T : struct
+{
+    protected T _baseValue;
+    protected float _multiplier;
+
+    public MathAttribute(T initialValue, float multiplier = 1.0f)
+    {
+        _baseValue = initialValue;
+        _multiplier = multiplier;
+        Validate();
+    }
+
+    // Public property to get the final calculated value
+    public T Value => CalculateFinalValue();
+    public float Multiplier => _multiplier;
+
+    public void Add(T amount)
+    {
+        _baseValue = PerformAdd(_baseValue, amount);
+        Validate();
+    }
+
+    public void Subtract(T amount)
+    {
+        _baseValue = PerformSubtract(_baseValue, amount);
+        Validate();
+    }
+
+    public void Multiply(T amount)
+    {
+        _baseValue = PerformMultiply(_baseValue, amount);
+        Validate();
+    }
+
+    public void Divide(T amount)
+    {
+        _baseValue = PerformDivide(_baseValue, amount);
+        Validate();
+    }
+
+    public void AddMultiplier(float additionalMultiplier)
+    {
+        _multiplier += additionalMultiplier;
+        Validate();
+    }
+
+    public void ResetMultiplier()
+    {
+        _multiplier = 1.0f;
+        Validate();
+    }
+
+    // --- Abstract Methods (To be implemented by concrete types) ---
+    protected abstract T PerformAdd(T a, T b);
+    protected abstract T PerformSubtract(T a, T b);
+    protected abstract T PerformMultiply(T a, T b);
+    protected abstract T PerformDivide(T a, T b);
+
+
+    // Concrete class decides how to apply the float multiplier to type T
+    protected abstract T CalculateFinalValue();
+
+    // Optional validation hook (e.g., clamping values)
+    protected virtual void Validate() { }
+}

--- a/Assets/Script/action/Attributes/MathAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/MathAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fbb46fb716c117240a43cc970267dc43

--- a/Assets/Script/action/Attributes/StringAttribute.cs
+++ b/Assets/Script/action/Attributes/StringAttribute.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class StringAttribute : IValueAttribute<string>
+{
+    private string _value;
+
+    public string Query()
+    {
+        return _value;
+    }
+
+    public bool Set(string newValue)
+    {
+        _value = newValue;
+        return true;
+    }
+
+    public StringAttribute(string initialValue)
+    {
+        _value = initialValue;
+    }
+}

--- a/Assets/Script/action/Attributes/StringAttribute.cs.meta
+++ b/Assets/Script/action/Attributes/StringAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4987e6fd140e55645a8f6929b1b4f149

--- a/Assets/Script/game_control/InGameManager.cs
+++ b/Assets/Script/game_control/InGameManager.cs
@@ -40,12 +40,6 @@ public class InGameManager
 
         EnvEntityManager = new EnvEntityManager();
 
-        // 啟用 EnvEntityManager 的 Tick 訂閱
-        if (EnvEntityManager != null)
-        {
-            TickManager?.RegisterTickable(EnvEntityManager.OnTick);
-        }
-
         // 紀錄初始化完成
         LogManager.Log("[Manager] 初始化完成");
     }


### PR DESCRIPTION
重構 Creature 類別，將多項 public 屬性改為建議以 Attribute 物件包裝，並新增泛型屬性包裝類別（如 BoolAttribute、FloatAttribute、ListAttribute 等）以提升型別安全與擴充性。加入 MathAttribute 抽象類別統一數值運算，新增 ColorAttr 管理顏色基因。調整 Unity 場景組件掛載，移除 InGameManager.cs 中多餘的 Tick 註冊，並補齊相關 .meta 檔案。